### PR TITLE
New body

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,6 +21,7 @@ let package = Package(
             name: "Harmonize",
             dependencies: [
                 .product(name: "SwiftSyntax", package: "swift-syntax"),
+                .product(name: "SwiftOperators", package: "swift-syntax"),
                 .product(name: "SwiftParser", package: "swift-syntax"),
                 "Yams",
                 "HarmonizeSemantics",
@@ -36,6 +37,12 @@ let package = Package(
         ),
         .target(name: "HarmonizeUtils"),
         .testTarget(name: "HarmonizeTests", dependencies: ["Harmonize"]),
-        .testTarget(name: "SemanticsTests", dependencies: ["HarmonizeSemantics"])
+        .testTarget(
+            name: "SemanticsTests",
+            dependencies: [
+                "HarmonizeSemantics",
+                .product(name: "SwiftOperators", package: "swift-syntax"),
+            ]
+        )
     ]
 )

--- a/Sources/Harmonize/Frontend/API/Filters/Array+BodyProviding.swift
+++ b/Sources/Harmonize/Frontend/API/Filters/Array+BodyProviding.swift
@@ -43,7 +43,7 @@ public extension Array where Element: Declaration & BodyProviding {
     func withStatements(_ predicate: ([String]) -> Bool) -> [Element] {
         with(\.body) {
             guard let body = $0 else { return false }
-            return predicate(body.statements)
+            return predicate(body.statements.map(\.description))
         }
     }
 

--- a/Sources/Harmonize/Frontend/API/Filters/Array+BodyProviding.swift
+++ b/Sources/Harmonize/Frontend/API/Filters/Array+BodyProviding.swift
@@ -24,6 +24,62 @@ import HarmonizeSemantics
 /// providing filtering functionality based on body.
 public extension Array where Element: Declaration & BodyProviding {
     /// Filters the array to include only elements with a body that satisfies the given predicate.
+    func withBody(_ predicate: (Body) -> Bool) -> [Element] {
+        with(\.body) {
+            guard let body = $0 else { return false }
+            return predicate(body)
+        }
+    }
+    
+    func withoutBody(_ predicate: (Body) -> Bool) -> [Element] {
+        withBody { !predicate($0) }
+    }
+    
+    func withAssignments(_ predicate: ([Assignment]) -> Bool) -> [Element] {
+        with(\.body) {
+            guard let body = $0 else { return false }
+            return predicate(body.assignments)
+        }
+    }
+    
+    func withoutAssignments(_ predicate: ([Assignment]) -> Bool) -> [Element] {
+        withAssignments { !predicate($0) }
+    }
+    
+    func withFunctionCalls(_ predicate: ([FunctionCall]) -> Bool) -> [Element] {
+        with(\.body) {
+            guard let body = $0 else { return false }
+            return predicate(body.functionCalls)
+        }
+    }
+    
+    func withoutFunctionCalls(_ predicate: ([FunctionCall]) -> Bool) -> [Element] {
+        withFunctionCalls { !predicate($0) }
+    }
+    
+    func withIfs(_ predicate: ([If]) -> Bool) -> [Element] {
+        with(\.body) {
+            guard let body = $0 else { return false }
+            return predicate(body.ifs)
+        }
+    }
+    
+    func withoutIfs(_ predicate: ([If]) -> Bool) -> [Element] {
+        withIfs { !predicate($0 )}
+    }
+    
+    func withSwitches(_ predicate: ([Switch]) -> Bool) -> [Element] {
+        with(\.body) {
+            guard let body = $0 else { return false }
+            return predicate(body.switches)
+        }
+    }
+    
+    func withoutSwitches(_ predicate: ([Switch]) -> Bool) -> [Element] {
+        withSwitches { !predicate($0) }
+    }
+    
+    /// Filters the array to include only elements with a body that satisfies the given predicate.
     ///
     /// - parameter predicate: A closure that takes a `String` representing the body of the element and returns
     ///   a Boolean value indicating whether the body meets the criteria.

--- a/Sources/Harmonize/Frontend/API/SourceCode/SwiftSourceCode.swift
+++ b/Sources/Harmonize/Frontend/API/SourceCode/SwiftSourceCode.swift
@@ -31,7 +31,7 @@ public final class SwiftSourceCode {
         // Not ideal as it will break lazy evaluation of the Source File Syntax.
         // 'Fine' for this initial release, but we must rework this when Harmonize
         // evolves to be a 'File Query' over swift files.
-        SourceFileSyntaxResolver(source: self, node: sourceFileSyntax)
+        SourceFileSyntaxResolver(source: self, node: foldedSourceFileSyntax ?? sourceFileSyntax)
     }()
 
     /// The URL pointing to the Swift source file, if provided. Nil if `source` is provided directly as string.
@@ -160,7 +160,11 @@ extension SwiftSourceCode: Equatable, Hashable  {
 
 internal extension SwiftSourceCode {
     var sourceFileSyntax: SourceFileSyntax {
-        cachedSyntaxTree.get(self)
+        syntaxTreeCache.get(self)
+    }
+    
+    var foldedSourceFileSyntax: SourceFileSyntax? {
+        foldedSyntaxTreeCache.get(self)
     }
 }
 

--- a/Sources/HarmonizeSemantics/Collector/DeclarationsCollector.swift
+++ b/Sources/HarmonizeSemantics/Collector/DeclarationsCollector.swift
@@ -193,18 +193,6 @@ package final class DeclarationsCollector: SyntaxVisitor {
         return .skipChildren
     }
     
-    public override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        _ = startScopeWith(node) {
-            FunctionCall(node: node, parent: parentDeclaration, sourceCodeLocation: sourceCodeLocation)
-        }
-        
-        return .visitChildren
-    }
-    
-    public override func visitPost(_ node: FunctionCallExprSyntax) {
-        endScope(for: node)
-    }
-    
     private func startScopeWith<T: Declaration>(_ node: SyntaxProtocol, make: () -> [T]) -> [T] {
         let newDeclarations = make()
         

--- a/Sources/HarmonizeSemantics/Declaration/Function.swift
+++ b/Sources/HarmonizeSemantics/Declaration/Function.swift
@@ -67,7 +67,6 @@ extension Function: NamedDeclaration,
                     BodyProviding,
                     ParametersProviding,
                     FunctionsProviding,
-                    FunctionCallsProviding,
                     SourceCodeProviding {
     public var attributes: [Attribute] {
         node.attributes.attributes
@@ -117,9 +116,5 @@ extension Function: NamedDeclaration,
     
     public var body: Body? {
         Body(node: node.body?.statements)
-    }
-
-    public var functionCalls: [FunctionCall] {
-        declarations.as(FunctionCall.self)
     }
 }

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Assignment.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Assignment.swift
@@ -1,0 +1,84 @@
+//
+//  Assignment.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// Represents an assignment expression in Swift syntax, specifically an infix operator assignment (e.g., `a = b`).
+public struct Assignment: DeclarationDecoration, SyntaxNodeProviding {
+    /// The underlying syntax node for the assignment expression.
+    public let node: InfixOperatorExprSyntax
+    
+    /// The target of the assignment expression (the left operand).
+    public var target: String {
+        node.leftOperand.trimmedDescription
+    }
+    
+    /// the assignment value after `=` (the right operand)
+    public var rightOperand: RightOperand {
+        if let functionCallNode = node.rightOperand.as(FunctionCallExprSyntax.self) {
+            return .functionCall(FunctionCall(node: functionCallNode))
+        }
+        
+        if let ref = node.rightOperand.as(DeclReferenceExprSyntax.self) {
+            let args = ref.argumentNames?.arguments.map(\.name.text) ?? []
+            return .reference(name: ref.baseName.text, arguments: args)
+        }
+        
+        if let stringLiteral = node.rightOperand.as(StringLiteralExprSyntax.self) {
+            return .literalStringValue(stringLiteral.segments.trimmedDescription)
+        }
+        
+        if let intLiteral = node.rightOperand.as(IntegerLiteralExprSyntax.self) {
+            return .literalIntValueText(intLiteral.literal.text)
+        }
+        
+        if let closureNode = node.rightOperand.as(ClosureExprSyntax.self) {
+            return .closure(Closure(node: closureNode))
+        }
+        
+        if let IfNode = node.rightOperand.as(IfExprSyntax.self) {
+            return .ifCondition(If(node: IfNode))
+        }
+        
+        return .unsupported(node.rightOperand.trimmedDescription)
+    }
+    
+    public var description: String {
+        node.trimmedDescription
+    }
+    
+    internal init(node: InfixOperatorExprSyntax) {
+        self.node = node
+    }
+}
+
+// MARK: Operands
+
+extension Assignment {
+    public enum RightOperand {
+        case reference(name: String, arguments: [String])
+        case literalStringValue(String)
+        case literalIntValueText(String)
+        case functionCall(FunctionCall)
+        case closure(Closure)
+        case ifCondition(If)
+        case unsupported(String)
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Closure.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Closure.swift
@@ -1,0 +1,148 @@
+//
+//  Closure.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// Represents a closure expression in Swift AST.
+/// This structure provides access to various components of a closure.
+public struct Closure: DeclarationDecoration, SyntaxNodeProviding {
+    public let node: ClosureExprSyntax
+    
+    /// The parameters of the closure, represented as an array of strings.
+    public var parameters: [String] {
+        if let shortHandParams = node.signature?.parameterClause?.as(ClosureShorthandParameterListSyntax.self) {
+            return shortHandParams.map(\.name.text)
+        }
+        
+        if let params = node.signature?.parameterClause?.as(ClosureParameterClauseSyntax.self) {
+            return params.parameters.map(\.firstName.text)
+        }
+        
+        return []
+    }
+    
+    /// The return clause of the closure, if any.
+    public var returnClause: ReturnClause? {
+        ReturnClause(node: node.signature?.returnClause)
+    }
+    
+    /// The captures of the closure, i.e., the values that are captured by the closure.
+    /// - Returns: An array of `Capture` objects representing each captured value. Returns an empty array if there are no captured values.
+    public var captures: [Capture] {
+        node.signature?.capture?.items.map(Capture.init(node:)) ?? []
+    }
+    
+    public var description: String {
+        node.trimmedDescription
+    }
+    
+    public func isCapturing(value: String) -> Bool {
+        return captures.contains(where: { $0.value == value })
+    }
+    
+    public func isCapturingWeak(value: String) -> Bool {
+        return captures.contains(where: { $0.isWeak() && $0.value == value })
+    }
+    
+    public func isCapturingUnowned(value: String) -> Bool {
+        return captures.contains(where: { $0.isUnowned() && $0.value == value })
+    }
+    
+    internal init(node: ClosureExprSyntax) {
+        self.node = node
+    }
+    
+    internal init?(node: ClosureExprSyntax?) {
+        guard let node else { return nil }
+        self.node = node
+    }
+}
+
+// MARK: - AttributesProviding Comformance
+
+extension Closure: AttributesProviding, BodyProviding {
+    public var attributes: [Attribute] {
+        node.signature?.attributes.attributes ?? []
+    }
+    
+    public var body: Body? {
+        Body(node: node.statements)
+    }
+}
+
+// MARK: - Capture
+
+extension Closure {
+    public struct Capture: DeclarationDecoration, SyntaxNodeProviding {
+        public enum Specifier: Equatable {
+            case weak
+            case unowned(detail: String)
+            
+            var description: String {
+                switch self {
+                case .weak: "weak"
+                case .unowned(detail: let detail): "unowned(\(detail))"
+                }
+            }
+        }
+        
+        /// The underlying syntax node for the capture.
+        public var node: ClosureCaptureSyntax
+        
+        /// A textual description of the statement, trimmed for readability.
+        public var description: String {
+            node.trimmedDescription
+        }
+        
+        /// The captured closure value specifier if any.
+        public var specifier: Specifier? {
+            switch node.specifier?.specifier.text {
+            case "weak": .weak
+            case "unowned": .unowned(detail: node.specifier?.detail?.text ?? "")
+            default: nil
+            }
+        }
+        
+        /// The text representation of the captured value.
+        public var value: String {
+            node.expression.trimmedDescription
+        }
+        
+        internal init(node: ClosureCaptureSyntax) {
+            self.node = node
+        }
+        
+        public func isWeak() -> Bool {
+            return specifier?.description == "weak"
+        }
+        
+        public func isUnowned() -> Bool {
+            return specifier?.description.contains("unowned") == true
+        }
+        
+        public func isSafeUnowned() -> Bool {
+            return specifier?.description == "unowned(safe)"
+        }
+        
+        public func isUnsafeUnowned() -> Bool {
+            return specifier?.description == "unowned(unsafe)"
+        }
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/If.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/If.swift
@@ -1,0 +1,58 @@
+//
+//  If.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftSyntax
+
+public struct If: DeclarationDecoration, SyntaxNodeProviding {
+    public let node: IfExprSyntax
+
+    public var description: String {
+        node.trimmedDescription
+    }
+    
+    public var conditions: [String] {
+        node.conditions.map(\.trimmedDescription)
+    }
+    
+    public var elseIf: If? {
+        Self(node: node.elseBody?.as(IfExprSyntax.self))
+    }
+    
+    public var elseBody: Body? {
+        Body(node: node.elseBody?.as(CodeBlockSyntax.self)?.statements)
+    }
+    
+    internal init(node: IfExprSyntax) {
+        self.node = node
+    }
+    
+    internal init?(node: IfExprSyntax?) {
+        guard let node else { return nil }
+        self.node = node
+    }
+}
+
+// MARK: BodyProviding comformance
+
+extension If: BodyProviding {
+    public var body: Body? {
+        Body(node: node.body.statements)
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Statement.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Statement.swift
@@ -1,0 +1,44 @@
+//
+//  Statement.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// A representation of a raw fallback statement within a code body.
+///
+/// The `Statement` struct is used to capture unsupported or unrecognized semantic elements
+/// found within a code body. This includes elements like variable declarations, which are
+/// intentionally excluded from being directly supported in the `Body` type since they are
+/// already categorized and accessible through their parent context (e.g via `.variables()`).
+///
+/// For example, if a variable declaration appears in the code block, it will be represented
+/// as a `Statement` in cases where it cannot be semantically resolved into a more specific type.
+public struct Statement: DeclarationDecoration, SyntaxNodeProviding {
+    /// The underlying syntax node for the statement.
+    public var node: CodeBlockItemSyntax
+    
+    /// A textual description of the statement, trimmed for readability.
+    public var description: String {
+        node.trimmedDescription
+    }
+    
+    internal init(node: CodeBlockItemSyntax) {
+        self.node = node
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Switch.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Switch.swift
@@ -1,0 +1,179 @@
+//
+//  Switch.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// A struct representing a `switch` expression in Swift code.
+///
+/// The `Switch` struct encapsulates the syntax node of a `switch` expression (`SwitchExprSyntax`)
+/// and provides an API to access its description, cases, and related metadata.
+public struct Switch: DeclarationDecoration, SyntaxNodeProviding {
+    /// The syntax node representing the `switch` expression in the abstract syntax tree (AST).
+    public let node: SwitchExprSyntax
+
+    /// A description of the `switch` expression, trimmed of leading/trailing whitespace.
+    ///
+    /// For example:
+    /// ```swift
+    /// switch value {
+    /// case 1: print("One")
+    /// default: break
+    /// }
+    /// ```
+    /// The description would be `"switch value { case 1: print(\"One\"); default: break }"`.
+    public var description: String {
+        node.trimmedDescription
+    }
+    
+    /// An array of cases present in the `switch` expression.
+    ///
+    /// Each case is represented by the `Switch.Case` struct, which provides details
+    /// such as the pattern, attribute, and body.
+    ///
+    /// Conditional compilation blocks (`#if`) are currently unsupported and will be ignored.
+    public var cases: [Case] {
+        node.cases.compactMap { $0.as(SwitchCaseSyntax.self) }
+            .map(Case.init(node:))
+    }
+    
+    internal init(node: SwitchExprSyntax) {
+        self.node = node
+    }
+    
+    internal init?(node: SwitchExprSyntax?) {
+        guard let node else { return nil }
+        self.node = node
+    }
+}
+
+// MARK: Case
+
+extension Switch {
+    /// A struct representing a single case in a `switch` expression.
+    ///
+    /// The `Switch.Case` struct provides access to details about a case, such as its pattern,
+    /// optional attribute, and body of statements.
+    public struct Case: DeclarationDecoration, SyntaxNodeProviding {
+        /// The syntax node representing the case in the abstract syntax tree (AST).
+        public let node: SwitchCaseSyntax
+        
+        /// A description of the case, trimmed of leading/trailing whitespace.
+        ///
+        /// For example:
+        /// ```swift
+        /// case .one: print("One")
+        /// ```
+        /// The description would be `"case .one: print(\"One\")"`.
+        public var description: String {
+            node.trimmedDescription
+        }
+        
+        /// An optional attribute associated with the case, such as `@unknown`.
+        public var attribute: Attribute? {
+            Attribute(node: node.attribute)
+        }
+        
+        /// Indicates whether the case is a `default` case.
+        public var isDefault: Bool {
+            return if case .default(_) = node.label {
+                true
+            } else {
+                false
+            }
+        }
+        
+        public init(node: SwitchCaseSyntax) {
+            self.node = node
+        }
+    }
+}
+
+// MARK: Switch.Case + BodyProviding
+
+extension Switch.Case: BodyProviding {
+    public var body: Body? {
+        Body(node: node.statements)
+    }
+}
+
+// MARK: Switch.Case + Item
+
+extension Switch.Case {
+    /// An enumeration representing the different patterns that can be used in a `switch` case.
+    /// Each pattern corresponds to a specific type of case item in the `switch` expression.
+    public enum Item: Equatable {
+        /// A case with a literal expression, such as `case 1`.
+        case literalExpression(String)
+                
+        /// A case with a named member, such as `case .one`.
+        case namedMember(String)
+        
+        /// A case with a type check, such as `case is String`.
+        case isType(String)
+        
+        /// A value-binding case with a single member, such as `case let .one(x)`.
+        case valueBindingWithMember(keyword: String, name: String, elements: [String])
+        
+        /// A nested value-binding case, such as `case let (x, y)` with detailed bindings.
+        case nestedValueBinding(name: String, elements: [String: String])
+        
+        /// A value-binding case with multiple elements, such as `case let (x, y)`.
+        case valueBinding(keyword: String, elements: [String])
+        
+        /// A case with a tuple pattern, such as `case (x, y)`.
+        case tuplePattern(elements: [String])
+        
+        /// A case with an unsupported pattern.
+        case unsupportedPattern(SwitchCaseItemSyntax)
+        
+        // MARK: Initializer
+        
+        public init(node: SwitchCaseItemSyntax) {
+            let pattern = node.pattern
+            
+            if let expressionPattern = pattern.as(ExpressionPatternSyntax.self) {
+                    self = .literalExpression(expressionPattern.description)
+            } else if let identifierPattern = pattern.as(IdentifierPatternSyntax.self) {
+                self = .namedMember(identifierPattern.identifier.text)
+            } else if let isTypePattern = pattern.as(IsTypePatternSyntax.self) {
+                self = .isType(isTypePattern.type.description)
+            } else if let valueBindingPattern = pattern.as(ValueBindingPatternSyntax.self) {
+                let keyword = valueBindingPattern.bindingSpecifier.text
+                if let identifierPattern = valueBindingPattern.pattern.as(IdentifierPatternSyntax.self) {
+                    self = .valueBindingWithMember(
+                        keyword: keyword,
+                        name: identifierPattern.identifier.text,
+                        elements: []
+                    )
+                } else if let tuplePattern = valueBindingPattern.pattern.as(TuplePatternSyntax.self) {
+                    let elements = tuplePattern.elements.map(\.pattern.trimmedDescription)
+                    self = .valueBinding(keyword: keyword, elements: elements)
+                } else {
+                    self = .unsupportedPattern(node)
+                }
+            } else if let tuplePattern = pattern.as(TuplePatternSyntax.self) {
+                let elements = tuplePattern.elements.map(\.trimmedDescription)
+                self = .tuplePattern(elements: elements)
+            } else {
+                self = .unsupportedPattern(node)
+            }
+        }
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Provider/BodyProviding.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Provider/BodyProviding.swift
@@ -18,7 +18,13 @@
 //
 
 /// A protocol that represents declarations capable of providing a body.
-public protocol BodyProviding {
+public protocol BodyProviding: FunctionCallsProviding {
     /// The body of the declaration, if any.
     var body: Body? { get }
+}
+
+extension BodyProviding {
+    public var functionCalls: [FunctionCall] {
+        body?.functionCalls ?? []
+    }
 }

--- a/Sources/HarmonizeSemantics/GrammarComponents/Provider/BodyProviding.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Provider/BodyProviding.swift
@@ -27,4 +27,67 @@ extension BodyProviding {
     public var functionCalls: [FunctionCall] {
         body?.functionCalls ?? []
     }
+    
+    // MARK: - Checks for Assignments
+        
+    /// Checks if the body contains an assignment to a variable with the specified name.
+    ///
+    /// - Parameter variableName: The name of the variable to check for.
+    /// - Returns: `true` if the body contains an assignment to the variable, otherwise `false`.
+    public func assigns(to variableName: String) -> Bool {
+        body?.assignments.contains { $0.target == variableName } ?? false
+    }
+    
+    /// Retrieves all assignments to the specified variable name.
+    ///
+    /// - Parameter variableName: The name of the variable.
+    /// - Returns: An array of assignments to the specified variable, or an empty array if none exist.
+    public func assignments(to variableName: String) -> [Assignment] {
+        body?.assignments.filter { $0.target == variableName } ?? []
+    }
+    
+    /// Checks if the body contains any assignments.
+    ///
+    /// - Returns: `true` if the body contains assignments, otherwise `false`.
+    public func hasAssignments() -> Bool {
+        body?.assignments.isEmpty == false
+    }
+        
+    /// Checks if the body contains any `if` statements.
+    ///
+    /// - Returns: `true` if the body contains `if` statements, otherwise `false`.
+    public func hasIfStatements() -> Bool {
+        body?.ifs.isEmpty == false
+    }
+    
+    /// Retrieves all `if` statements in the body.
+    ///
+    /// - Returns: An array of `If` objects representing all `if` statements, or an empty array if none exist.
+    public func ifStatements() -> [If] {
+        body?.ifs ?? []
+    }
+        
+    /// Checks if the body contains any `switch` statements.
+    ///
+    /// - Returns: `true` if the body contains `switch` statements, otherwise `false`.
+    public func hasSwitchStatements() -> Bool {
+        body?.switches.isEmpty == false
+    }
+    
+    /// Retrieves all `switch` statements in the body.
+    ///
+    /// - Returns: An array of `Switch` objects representing all `switch` statements, or an empty array if none exist.
+    public func switchStatements() -> [Switch] {
+        body?.switches ?? []
+    }
+    
+    /// Checks if the body is empty (contains no statements, assignments, or function calls).
+    ///
+    /// - Returns: `true` if the body is empty, otherwise `false`.
+    public func isEmptyBody() -> Bool {
+        let isEmpty = body?.statements.isEmpty ?? true
+        let hasNoAssignments = body?.assignments.isEmpty ?? true
+        let hasNoFunctionCalls = body?.functionCalls.isEmpty ?? true
+        return isEmpty && hasNoAssignments && hasNoFunctionCalls
+    }
 }

--- a/Tests/HarmonizeTests/Tests/AssertionsFailuresTests.swift
+++ b/Tests/HarmonizeTests/Tests/AssertionsFailuresTests.swift
@@ -43,7 +43,7 @@ final class AssertionsFailuresTests: XCTestCase {
     }
 }
 
-fileprivate extension AssertionsFailuresTests {
+internal extension AssertionsFailuresTests {
     /// Adapted from original source:
     /// https://medium.com/@matthew_healy/cuteasserts-dev-blog-1-wait-how-do-you-test-that-a-test-failed-37419eb33b49
     final class ExpectedFailureTestCaseRun: XCTestCaseRun {

--- a/Tests/HarmonizeTests/Tests/LintRulesExamplesTests.swift
+++ b/Tests/HarmonizeTests/Tests/LintRulesExamplesTests.swift
@@ -1,0 +1,71 @@
+//
+//  LintRulesExamplesTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import Harmonize
+import XCTest
+
+final class LintRulesExamplesTests: XCTestCase {
+    override var testRunClass: AnyClass? {
+        return AssertionsFailuresTests.ExpectedFailureTestCaseRun.self
+    }
+    
+    func testNoSideEffects() throws {
+        Harmonize.on { Self.ViewModel }
+            .classes()
+            .initializers()
+            .withFunctionCalls { functionCalls in
+                let closures = functionCalls.compactMap(\.closure)
+                let hasAssignmentToSelf = closures.filter {
+                    $0.body?.assignments.contains { $0.target.contains("self") } == true
+                }
+                
+                return hasAssignmentToSelf.isNotEmpty
+            }
+            .assertEmpty(message: "Side-effect are not allowed in initializers since they are hard to test when using test schedulers")
+    }
+    
+    // This is just an example
+    func testNoIfOnInitializers() throws {
+        Harmonize.on { Self.ViewModel }
+            .classes()
+            .withInitializers { $0.hasIfStatements() }
+            .assertEmpty(message: "We don't like if-else conditions in initializers. Consider cleaning up your code.")
+    }
+    
+    private static let ViewModel: String = """
+        class UserViewModel: ObservableObject {
+            private var cancellables = Set<AnyCancellable>()
+            @Published var userName: String = "Loading..."
+           
+            init(userId: Int) {
+                if userId == 42 {
+                    self.userName = "Offline Profile #42"
+                } else {
+                    self.userName = "Loading Profile #0"
+                }
+    
+                fetchUserIO(userId: userId) {
+                    self.userName = $0
+                }
+            }
+            
+            private func fetchUserIO(userId: Int, completion: @escaping (String) -> Void) {
+                URLSession.shared.dataTaskPublisher(for: URL(string: "https://example.com/users/\\(userId)")!)
+                    .map { data, _ in
+                        String(data: data, encoding: .utf8) ?? "Unknown User"
+                    }
+                    .replaceError(with: "Error fetching user")
+                    .sink { userName in
+                        completion(userName)
+                    }
+                    .store(in: &cancellables)
+            }
+        }
+
+    """
+}

--- a/Tests/SemanticsTests/BodyTests.swift
+++ b/Tests/SemanticsTests/BodyTests.swift
@@ -1,0 +1,152 @@
+//
+//  BodyTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import HarmonizeSemantics
+import XCTest
+import SwiftSyntax
+
+final class BodyTests: XCTestCase {
+    private var sourceSyntax = """
+    public final class Klass {
+        private static let Defaults = 999
+
+        let value: Int
+        let value2: String
+        let closure: () -> Int
+        let conditionalValue: Int
+
+        public init(value: Int) {
+            self.value = value // ref
+            self.value = 2 // intLiteral
+            value2 = "StringLiteral" // stringLiteral
+            value2 = generateRandomNumber() // functionCall
+            closure = { 9 }
+            conditionalValue = if closure() < 9 { 9 } else { 0 } // ifCondition
+            self.value = [1, 2].first ?? 0 // unsupported
+
+            closureElsewhere { [weak self] in
+                (self?.value ?? 0) * $0
+            }
+    
+            listenToSomeHeavyData()
+    
+            if value > 2 {
+                performSomeTask()
+            }
+    
+            if closure() > 9 {
+                doSomeOtherStuff()
+            }
+    
+            switch value {
+                case 9: 
+                    print("Cool!")
+                case 2:
+                    print("Not so cool!")
+                default:
+                    print("Yeah I know nothing")
+            }
+        }
+        
+        func closureElsewhere(f: (Int) -> Void) {
+            f(42)
+        }
+    }
+    """.parsed()
+    
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
+    
+    override func setUp() {
+        visitor.walk(sourceSyntax)
+    }
+    
+    func testParsesAssignments() throws {
+        let initializer = visitor.classes.first!.initializers.first!
+        let assignments = initializer.body!.assignments
+        let targets = assignments.map(\.target)
+        let rhs = assignments.map(\.rightOperand)
+        
+        let expectedTargets = [
+            "self.value",
+            "self.value",
+            "value2",
+            "value2",
+            "closure",
+            "conditionalValue",
+            "self.value"
+        ]
+        
+        XCTAssertEqual(assignments.count, 7)
+        XCTAssertEqual(targets, expectedTargets)
+        
+        // RightOperand isn't yet equatable
+        rhs.enumerated().forEach { index, rhs in
+            if case let .literalIntValueText(text) = rhs {
+                XCTAssertEqual(text, "2")
+            }
+            
+            if case let .literalStringValue(text) = rhs {
+                XCTAssertEqual(text, "StringLiteral")
+            }
+            
+            if case let .functionCall(functionCall) = rhs {
+                XCTAssertEqual(functionCall.call, "generateRandomNumber")
+            }
+            
+            if case let .closure(closure) = rhs {
+                XCTAssertEqual(closure.body!.description, "9")
+            }
+            
+            if case let .ifCondition(ifCondition) = rhs {
+                XCTAssertEqual(ifCondition.conditions, ["closure() < 9"])
+            }
+            
+            if case let .reference(name, _) = rhs {
+                XCTAssertEqual(name, "value")
+            }
+            
+            if case let .unsupported(text) = rhs {
+                XCTAssertEqual(text, "[1, 2].first ?? 0")
+            }
+        }
+    }
+    
+    func testParsesFunctionCalls() throws {
+        let initializer = visitor.classes.first!.initializers.first!
+        let functionCalls = initializer.body!.functionCalls
+        
+        XCTAssertEqual(functionCalls.count, 2)
+        XCTAssertEqual(functionCalls[0].call, "closureElsewhere")
+        XCTAssertTrue(functionCalls[0].closure!.isCapturingWeak(value: "self"))
+        XCTAssertEqual(functionCalls[1].call, "listenToSomeHeavyData")
+    }
+    
+    func testParsesIfs() throws {
+        let initializer = visitor.classes.first!.initializers.first!
+        let ifs = initializer.body!.ifs
+        
+        XCTAssertEqual(ifs.count, 2)
+        XCTAssertEqual(ifs[0].conditions, ["value > 2"])
+        XCTAssertEqual(ifs[1].conditions, ["closure() > 9"])
+    }
+    
+    func testParsesSwitches() throws {
+        let initializer = visitor.classes.first!.initializers.first!
+        let switches = initializer.body!.switches
+        
+        XCTAssertEqual(switches.count, 1)
+        XCTAssertEqual(switches.first!.cases.count, 3)
+    }
+}

--- a/Tests/SemanticsTests/FunctionsTests.swift
+++ b/Tests/SemanticsTests/FunctionsTests.swift
@@ -242,10 +242,13 @@ final class FunctionsTests: XCTestCase {
         XCTAssertEqual(functionBody, content)
     }
 
-    func testParseFunctionBodyStatements() throws {
-        let functionBody = named("withReturnClause").body?.statements
-        let lines = ["let cal = \"cal\"", "noLabelAtAll(cal)", "return \"return\""]
-        XCTAssertEqual(functionBody, lines)
+    func testParseFunctionBody() throws {
+        let functionBody = named("withReturnClause").body!
+        let statements = functionBody.statements
+        let functionCall = functionBody.functionCalls.first!
+        
+        XCTAssertEqual(statements.map(\.description), ["let cal = \"cal\"", "return \"return\""])
+        XCTAssertEqual(functionCall.call, "noLabelAtAll")
     }
 
     func testParseFunctionBodyFunctionCalls() throws {

--- a/Tests/SemanticsTests/ImportsTests.swift
+++ b/Tests/SemanticsTests/ImportsTests.swift
@@ -1,5 +1,5 @@
 //
-//  FunctionsTests.swift
+//  ImportsTests.swift
 //  Harmonize
 //
 //  Copyright (c) Perry Street Software 2024. All Rights Reserved.

--- a/Tests/SemanticsTests/InitializersTests.swift
+++ b/Tests/SemanticsTests/InitializersTests.swift
@@ -1,5 +1,5 @@
 //
-//  FunctionsTests.swift
+//  InitializersTests.swift
 //  Harmonize
 //
 //  Copyright (c) Perry Street Software 2024. All Rights Reserved.
@@ -124,11 +124,13 @@ final class InitializersTests: XCTestCase {
         """
         XCTAssertEqual(initializerContent, content)
     }
-
-    func testParseInitializersBodyStatements() throws {
-        let initializer = visitor.structs.flatMap(\.initializers).first
-        let initializerStatements = initializer?.body?.statements
-        let statements = ["self.property = property", "var _ = \"bar\""]
-        XCTAssertEqual(initializerStatements, statements)
+    
+    func testParseFunctionBody() throws {
+        let body = visitor.structs.flatMap(\.initializers).first!.body!
+        let statements = body.statements
+        let assignment = body.assignments.first!
+        
+        XCTAssertEqual(statements.map(\.description), ["var _ = \"bar\""])
+        XCTAssertEqual(assignment.target, "self.property")
     }
 }

--- a/Tests/SemanticsTests/ProtocolsTests.swift
+++ b/Tests/SemanticsTests/ProtocolsTests.swift
@@ -1,5 +1,5 @@
 //
-//  FunctionsTests.swift
+//  ProtocolTests.swift
 //  Harmonize
 //
 //  Copyright (c) Perry Street Software 2024. All Rights Reserved.

--- a/Tests/SemanticsTests/StructsTests.swift
+++ b/Tests/SemanticsTests/StructsTests.swift
@@ -1,5 +1,5 @@
 //
-//  FunctionsTests.swift
+//  StructsTests.swift
 //  Harmonize
 //
 //  Copyright (c) Perry Street Software 2024. All Rights Reserved.

--- a/Tests/SemanticsTests/Util/Parser.swift
+++ b/Tests/SemanticsTests/Util/Parser.swift
@@ -6,10 +6,15 @@
 //
 
 import SwiftSyntax
+import SwiftOperators
 import SwiftParser
 
 extension String {
     func parsed() -> SourceFileSyntax {
-        Parser.parse(source: self)
+        let parsed = Parser.parse(source: self)
+        
+        return OperatorTable.standardOperators
+            .foldAll(parsed) { _ in }
+            .as(SourceFileSyntax.self) ?? parsed
     }
 }

--- a/Tests/SemanticsTests/VariablesTests.swift
+++ b/Tests/SemanticsTests/VariablesTests.swift
@@ -1,5 +1,5 @@
 //
-//  FunctionsTests.swift
+//  VariablesTests.swift
 //  Harmonize
 //
 //  Copyright (c) Perry Street Software 2024. All Rights Reserved.
@@ -176,12 +176,12 @@ final class VariablesTests: XCTestCase {
 
     func testParseVariablesAccessorsBodyLines() throws {
         let variables = visitor.variables
-        let accessors = variables.flatMap { $0.accessors }.map { $0.body?.statements }
-
-        let accessor1 = ["print(\"a\")", "return example12"]
-        let accessor2 = ["example12 = newValue"]
-        XCTAssertEqual(accessors.count, 2)
-        XCTAssertEqual(accessors, [accessor1, accessor2])
+//        let accessors = variables.flatMap { $0.accessors }.map { $0.body?.statements }
+//
+//        let accessor1 = ["print(\"a\")", "return example12"]
+//        let accessor2 = ["example12 = newValue"]
+//        XCTAssertEqual(accessors.count, 2)
+//        XCTAssertEqual(accessors, [accessor1, accessor2])
     }
 
     func testParseVariablesGetterBody() throws {

--- a/Tests/SemanticsTests/VariablesTests.swift
+++ b/Tests/SemanticsTests/VariablesTests.swift
@@ -176,12 +176,11 @@ final class VariablesTests: XCTestCase {
 
     func testParseVariablesAccessorsBodyLines() throws {
         let variables = visitor.variables
-//        let accessors = variables.flatMap { $0.accessors }.map { $0.body?.statements }
-//
-//        let accessor1 = ["print(\"a\")", "return example12"]
-//        let accessor2 = ["example12 = newValue"]
-//        XCTAssertEqual(accessors.count, 2)
-//        XCTAssertEqual(accessors, [accessor1, accessor2])
+        let bodies = variables.flatMap { $0.accessors }.compactMap { $0.body }
+
+        XCTAssertEqual(bodies[0].functionCalls.count, 1)
+        XCTAssertEqual(bodies[0].statements.count, 1)
+        XCTAssertEqual(bodies[1].assignments.count, 1)
     }
 
     func testParseVariablesGetterBody() throws {


### PR DESCRIPTION
This PR introduces the new Body model which aims to be more aligned with the Swift language model, although we still need more work in the future to support more features, this is a good addition to have a clean high-level abstraction when writing tests.

This is now possible:

```swift
// See more at LintRulesExamplesTests
func testNoSideEffects() throws {
        Harmonize.on { Self.ViewModel }
            .classes()
            .initializers()
            .withFunctionCalls { functionCalls in
                let closures = functionCalls.compactMap(\.closure)
                let hasAssignmentToSelf = closures.filter {
                    $0.body?.assignments.contains { $0.target.contains("self") } == true
                }

                return hasAssignmentToSelf.isNotEmpty
            }
            .assertEmpty(message: "Side-effect are not allowed in initializers since they are hard to test when using test schedulers")
    }

```

These changes were made:

- Function call is not a top-level declaration anymore, since this never made sense and was kinda of a workaround, we moved it back to be a component. However we lost source code location in such model and it is for now disable.

**Note**: the current source code location for declarations feels like a mess and we need to rethink about it because we need to pass parent declarations all the way down to its children. Maybe Harmonize can figure it out automatically using its scoped instace.

Body will now expose:

- Assignments (e.g: `self.value = someValue()`)
- If conditions
- Switch statements
- Function Calls
- Statements (aka unsupported stuff)

We added a bunch of methods as well such as `hasIfStatements()` and those model can be used for linting since they have more power now.

--

Fix #32 #17 