### PR TITLE
Rework nested function calls parsing.

### DIFF
--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/FunctionCall.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/FunctionCall.swift
@@ -62,6 +62,11 @@ public struct FunctionCall: DeclarationDecoration, SyntaxNodeProviding {
     public var closure: Closure? {
         Closure(node: node.trailingClosure)
     }
+    
+    /// - Returns: if the given function call is a trailing closure.
+    public var isClosure: Bool {
+        closure != nil
+    }
 
     public var tokens: [Token] {
         return node.tokens(viewMode: .all)
@@ -135,10 +140,6 @@ public extension FunctionCall {
 
 extension FunctionCall: FunctionCallsProviding {
     public var functionCalls: [FunctionCall] {
-        node.children(viewMode: .all)
-            .compactMap {
-                $0.as(FunctionCallExprSyntax.self)
-            }
-            .map(FunctionCall.init(node:))
+        closure?.functionCalls ?? []
     }
 }

--- a/Tests/Fixtures/Filters/FunctionCalls/FunctionCallsSample.swift
+++ b/Tests/Fixtures/Filters/FunctionCalls/FunctionCallsSample.swift
@@ -1,0 +1,59 @@
+//
+//  FunctionCallsSample.swift
+//
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+class FunctionCallsSample {
+    class TestFactory {
+        var value: Int?
+        
+        func withValue(_ value: Int) -> TestFactory {
+            self.value = value
+            return self
+        }
+    }
+    
+    class Something {
+        func onTap() {}
+    }
+    
+    func spec() {
+        beforeEach {
+            TestFactory().withValue(1)
+        }
+
+        given("something") {
+            then("there is something that will happen") {
+                // ...
+            }
+
+            when("it happens") {
+                beforeEach {
+                    something.onTap()
+                }
+                
+                then("I see it finally happens") {
+                    // ...
+                }
+            }
+        }
+    }
+    
+    private func beforeEach(_ body: () -> Void) {
+        // ...
+    }
+    
+    private func given(_ that: String, body: () -> Void) {
+        // ...
+    }
+    
+    private func when(_ that: String, body: () -> Void) {
+        // ...
+    }
+    
+    private func then(_ that: String, body: () -> Void) {
+        // ...
+    }
+}

--- a/Tests/HarmonizeTests/Tests/Filters/FunctionCallTests.swift
+++ b/Tests/HarmonizeTests/Tests/Filters/FunctionCallTests.swift
@@ -1,0 +1,36 @@
+//
+//  FunctionCallTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import HarmonizeSemantics
+import Harmonize
+import XCTest
+
+final class FunctionCallTests: XCTestCase {
+    let sampleCode = Harmonize.on("Filters/FunctionCalls")
+    
+    func testFunctionCallInvokes() throws {
+        // e.g every spec must have a `describe`
+        sampleCode.classes()
+            .functions()
+            .withName("spec")
+            .assertTrue {
+                $0.invokes("beforeEach")
+            }
+    }
+    
+    func testFunctionCallInvokesRecursively() {
+        // e.g every `describe` must call `TestFactory().withValue(1)` on its `beforeEach`
+        // so `invokes` must be able to do a nested check here.
+        sampleCode.classes()
+            .functions()
+            .withName("spec")
+            .assertTrue {
+                $0.invokes("TestFactory().withValue", recursively: true) &&
+                $0.invokes("something.onTap", recursively: true)
+            }
+    }
+}

--- a/Tests/SemanticsTests/FunctionCallTests.swift
+++ b/Tests/SemanticsTests/FunctionCallTests.swift
@@ -1,0 +1,86 @@
+//
+//  FunctionCallTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import HarmonizeSemantics
+import XCTest
+import SwiftSyntax
+
+final class FunctionCallTests: XCTestCase {
+    private var sourceSyntax = """
+    public final class SampleTest: QuickSpec {
+        override class func spec() {
+            describe("SampleTestCase") {
+                beforeEach {
+                    TestFactory().withValue(1)
+                }
+
+                Given("something") {
+                    Then("there is something that will happen") {
+                        expect(expectation) == .willHappen
+                    }
+    
+                    When("it happens") {
+                        beforeEach {
+                            something.onTap()
+                        }
+                        
+                        Then("I see it finally happens") {
+                            expect(expectation) == .isHappening
+                        }
+                    }
+                }
+            }
+        }
+    }
+    """.parsed()
+    
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
+    
+    private var sampleTestClass: Class {
+        visitor.classes.first!
+    }
+    
+    private var specFunction: Function {
+        sampleTestClass.functions.first!
+    }
+    
+    override func setUp() {
+        visitor.walk(sourceSyntax)
+    }
+    
+    func testParsingTopLevelFunctionCall() {
+        let describe = specFunction.functionCalls.first!
+        XCTAssertTrue(describe.call == "describe")
+    }
+    
+    func testParsingFunctionCallWithArguments() {
+        let describe = specFunction.functionCalls.first!
+        let arguments = describe.arguments
+
+        XCTAssertTrue(arguments.count == 1)
+        XCTAssertEqual("\"SampleTestCase\"", arguments.first!.value)
+    }
+    
+    func testParsingFunctionCallClosure() {
+        let describe = specFunction.functionCalls.first!
+        XCTAssertTrue(describe.isClosure)
+    }
+    
+    func testParsingInnerFunctionCalls() {
+        let describe = specFunction.functionCalls.first!
+        let calls = describe.functionCalls.map(\.call)
+        XCTAssertEqual(["beforeEach", "Given"], calls)
+    }
+}


### PR DESCRIPTION
Changes:

- Update `invokes` to add `recursively` optional check. If set to `true` it will traverse through function call of function call for matching with the given predicate (the expected calling function).
- Fix a case where `functionCalls` from `FunctionCall` where always empty. Our parsing were broken.
- Add more tests for function calls.
- Add `isClosure` check as well

Example:

```swift
func example() {
    functionCall1()
    closure {
        functionCall3()
    }
}

// ..

functions().assertTrue { $0.invokes("functionCall1") } // works!
functions().assertTrue { $0.invokes("functionCall3", recursively: true) } // works!
```