### PR TITLE
Rework FunctionCall component to support parsing inlined function call expression.

### DIFF
--- a/Sources/Harmonize/Frontend/API/Filters/Array+BodyProviding.swift
+++ b/Sources/Harmonize/Frontend/API/Filters/Array+BodyProviding.swift
@@ -44,20 +44,20 @@ public extension Array where Element: Declaration & BodyProviding {
 
     /// Filters the array to include only elements whose body contains assignments that satisfy the given predicate.
     ///
-    /// - parameter predicate: A closure that takes an array of `Assignment` objects and returns a Boolean value indicating whether the assignments meet the criteria.
+    /// - parameter predicate: A closure that takes an array of ``InfixExpression`` objects and returns a Boolean value indicating whether the assignments meet the criteria.
     /// - returns: An array of elements whose assignments match the specified predicate.
-    func withAssignments(_ predicate: ([Assignment]) -> Bool) -> [Element] {
+    func withAssignments(_ predicate: ([InfixExpression]) -> Bool) -> [Element] {
         with(\.body) {
             guard let body = $0 else { return false }
-            return predicate(body.assignments)
+            return predicate(body.infixExpressions.filter(\.isAssignment))
         }
     }
 
     /// Filters the array to include only elements whose body contains assignments that do not satisfy the given predicate.
     ///
-    /// - parameter predicate: A closure that takes an array of `Assignment` objects and returns a Boolean value indicating whether the assignments meet the criteria.
+    /// - parameter predicate: A closure that takes an array of ``InfixExpression`` objects and returns a Boolean value indicating whether the assignments meet the criteria.
     /// - returns: An array of elements whose assignments do not match the specified predicate.
-    func withoutAssignments(_ predicate: ([Assignment]) -> Bool) -> [Element] {
+    func withoutAssignments(_ predicate: ([InfixExpression]) -> Bool) -> [Element] {
         withAssignments { !predicate($0) }
     }
 

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Condition.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Condition.swift
@@ -1,0 +1,215 @@
+//
+//  Condition.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Foundation
+import SwiftSyntax
+
+/// A struct that represents a `condition` statement in Swift code, usually present in `if`,  `guard` etc.
+/// This might not support all possible condition statement and if it doesn't it will fallback to `.asString` value.
+public struct Condition: DeclarationDecoration, SyntaxNodeProviding {
+    public let node: ConditionElementSyntax
+    
+    /// An typed enum with all the possible condition statement expression types.
+    public var value: Value {
+        return if let optionalBinding = node.condition.as(OptionalBindingConditionSyntax.self) {
+            .optionalBinding(.init(node: optionalBinding))
+        } else if let comparison = node.condition.as(InfixOperatorExprSyntax.self) {
+            .comparison(.init(node: comparison))
+        } else if let booleanExpression = node.condition.as(MemberAccessExprSyntax.self) {
+            .booleanExpression(booleanExpression.trimmedDescription)
+        } else if let operatorBoolExpression = node.condition.as(PrefixOperatorExprSyntax.self) {
+            .booleanExpression(operatorBoolExpression.trimmedDescription)
+        } else {
+            .asString(node.condition.description)
+        }
+    }
+    
+    /// An optional value that returns non nil if this condition is a optional binding statement.
+    ///
+    /// - Returns: The value in cases like `if let..` or `guard let...`. Nil otherwise.
+    public var asOptionalBinding: OptionalBinding? {
+        return if case .optionalBinding(let optionalBinding) = value {
+            optionalBinding
+        } else {
+            nil
+        }
+    }
+    
+    /// An optional value that returns non nil if this condition is a comparison between a left and right operand.
+    ///
+    /// - Returns: The value in cases like `a > b`. Nil otherwise.
+    public var asComparison: InfixExpression? {
+        return if case .comparison(let infixExpression) = value {
+            infixExpression
+        } else {
+            nil
+        }
+    }
+    
+    /// - Returns: The raw value as a string.
+    public var asString: String {
+        return switch value {
+        case let .asString(string):
+            string
+        case let .booleanExpression(string):
+            string
+        case let .comparison(comparison):
+            comparison.description
+        case let .optionalBinding(binding):
+            binding.description
+        }
+    }
+    
+    /// A boolean flag that indicates if this condition is an optional binding and the binding target is self.
+    public var isBindingToSelf: Bool {
+        return asOptionalBinding?.isBindingSelf ?? false
+    }
+    
+    /// A boolean flag that indicates if this condition is an optional binding.
+    public var isOptionalBinding: Bool {
+        switch value {
+        case .optionalBinding(_):
+            true
+        default:
+            false
+        }
+    }
+    
+    /// A boolean flag that indicates if this condition is a boolean expression.
+    public var isBooleanExpression: Bool {
+        switch value {
+        case .booleanExpression(_):
+            true
+        default:
+            false
+        }
+    }
+    
+    /// A boolean flag that indicates if this condition is a comparison.
+    public var isComparison: Bool {
+        switch value {
+        case .comparison(_):
+            true
+        default:
+            false
+        }
+    }
+    
+    public var description: String {
+        node.trimmedDescription
+    }
+    
+    init(node: ConditionElementSyntax) {
+        self.node = node
+    }
+}
+
+// MARK: Condition + Value, OptionalBinding
+
+extension Condition {
+    /// A struct representing the possible cases for a condition.
+    public enum Value {
+        case optionalBinding(OptionalBinding)
+        case comparison(InfixExpression)
+        case booleanExpression(String)
+        case asString(String)
+    }
+    
+    /// A struct representing an optional binding condition in a Swift declaration.
+    ///
+    /// This struct is designed to capture the details of an optional binding condition, such as the type of binding (`let`, `var`, `inout`),
+    /// the associated type annotation, and whether the binding references `self`.
+    public struct OptionalBinding: DeclarationDecoration, SyntaxNodeProviding {
+        /// The syntax node representing the optional binding condition in the abstract syntax tree (AST).
+        public let node: OptionalBindingConditionSyntax
+        
+        public var description: String {
+            node.trimmedDescription
+        }
+        
+        /// The name of the binding variable.
+        ///
+        /// This property extracts the name of the variable being bound in the optional binding, such as `"abc"` in `guard let abc = ...`.
+        public var name: String {
+            if let identifier = node.as(IdentifierPatternSyntax.self) {
+                return identifier.identifier.text
+            }
+            
+            return node.pattern.trimmedDescription
+        }
+        
+        /// A boolean indicating whether the binding is a `let` binding.
+        ///
+        /// This property returns `true` if the optional binding uses the `let` keyword, as in `guard let abc = someValue`.
+        public var isLet: Bool {
+            node.bindingSpecifier.tokenKind == .keyword(.let)
+        }
+        
+        /// A boolean indicating whether the binding is a `var` binding.
+        ///
+        /// This property returns `true` if the optional binding uses the `var` keyword, as in `guard var abc = someValue`.
+        public var isVar: Bool {
+            node.bindingSpecifier.tokenKind == .keyword(.var)
+        }
+        
+        /// A boolean indicating whether the binding is an `inout` binding.
+        ///
+        /// This property returns `true` if the optional binding uses the `inout` keyword, as in `guard let abc = &someValue`.
+        public var isInOut: Bool {
+            node.bindingSpecifier.tokenKind == .keyword(.inout)
+        }
+        
+        /// A boolean indicating if the optional binding contains a self-binding reference.
+        ///
+        /// This property returns `true` if the left or right operand of the binding is a reference to `self`,
+        /// which is common in patterns like `guard let self = self` or `guard let abc = self`.
+        ///
+        /// - Returns: `true` if the left or right operand is `self`, `false` otherwise.
+        public var isBindingSelf: Bool {
+            node.pattern.as(IdentifierPatternSyntax.self)?.identifier.tokenKind == .keyword(.`self`) || initializerClause?.isSelfReference == true
+        }
+        
+        /// Initializes a new `OptionalBinding` from the given syntax node.
+        ///
+        /// This initializer creates an `OptionalBinding` instance from an `OptionalBindingConditionSyntax` node.
+        ///
+        /// - Parameter node: The syntax node representing the optional binding condition.
+        /// - Returns: A new instance of `OptionalBinding` initialized with the given node.
+        public init(node: OptionalBindingConditionSyntax) {
+            self.node = node
+        }
+    }
+}
+
+// MARK: Condition.OptionalBinding + Providers Comformance
+
+extension Condition.OptionalBinding: TypeProviding, InitializerClauseProviding {
+    /// The type annotation associated with the optional binding, if any.
+    public var typeAnnotation: TypeAnnotation? {
+        TypeAnnotation(node: node.typeAnnotation?.type)
+    }
+    
+    /// The initializer clause associated with the optional binding, if any.
+    ///
+    /// This property returns an `InitializerClause` that represents the initializer part of the binding, such as the right-hand side
+    /// expression in `guard let abc = someValue`.
+    public var initializerClause: InitializerClause? {
+        InitializerClause(node: node.initializer)
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Else.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Else.swift
@@ -1,5 +1,5 @@
 //
-//  If.swift
+//  Else.swift
 //  Harmonize
 //
 //  Copyright 2024 Perry Street Software Inc.
@@ -20,39 +20,27 @@
 import Foundation
 import SwiftSyntax
 
-public struct If: DeclarationDecoration, SyntaxNodeProviding {
-    public let node: IfExprSyntax
+public struct Else: DeclarationDecoration, SyntaxNodeProviding {
+    public let node: CodeBlockSyntax
 
     public var description: String {
         node.trimmedDescription
     }
-        
-    public var elseIf: If? {
-        Self(node: node.elseBody?.as(IfExprSyntax.self))
-    }
     
-    public var `else`: Else? {
-        Else(node: node.elseBody?.as(CodeBlockSyntax.self))
-    }
-    
-    internal init(node: IfExprSyntax) {
+    internal init(node: CodeBlockSyntax) {
         self.node = node
     }
     
-    internal init?(node: IfExprSyntax?) {
+    internal init?(node: CodeBlockSyntax?) {
         guard let node else { return nil }
         self.node = node
     }
 }
 
-// MARK: Providers comformance
+// MARK: BodyProviding comformance
 
-extension If: BodyProviding, ConditionsProviding {
+extension Else: BodyProviding {
     public var body: Body? {
-        Body(node: node.body.statements)
-    }
-    
-    public var conditions: [Condition] {
-        node.conditions.map(Condition.init(node:))
+        Body(node: node.statements)
     }
 }

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/FunctionCall.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/FunctionCall.swift
@@ -29,9 +29,61 @@ public struct FunctionCall: DeclarationDecoration, SyntaxNodeProviding {
     /// This property extracts and returns the called expression (e.g., the function name or method) in its trimmed form.
     /// For example, in the function call `print("Hello")`, the `call` is `"print"`.
     public var call: String {
-        node.calledExpression.trimmedDescription
+        if let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self) {
+            return memberAccess.declName.baseName.text
+        } else if let ref = node.calledExpression.as(DeclReferenceExprSyntax.self) {
+            return ref.baseName.text
+        }
+        
+        return node.calledExpression.trimmedDescription
     }
     
+    /// Returns all nested inline calls present in this function call, if any.
+    ///
+    /// Given the following code
+    /// ```swift
+    /// func function() {
+    ///     Call()
+    ///         .reference
+    ///         .call()
+    ///         .reference2
+    ///         .call()
+    /// }
+    /// ```
+    ///
+    /// This property would return `[Call(), "call", "call"]`.
+    public var inlineCalls: [FunctionCall] {
+        let calls = internalInlineCalls
+        return calls.isEmpty ? [] : calls + [self]
+    }
+    
+    /// Returns all closures present in this function call if it is an inlined function call expression, or its single closure if any.
+    /// This will return empty if this function has no trailing closure at all.
+    public var inlineClosures: [Closure] {
+        (internalInlineCalls.map(\.closure) + [closure]).compactMap(\.self)
+    }
+    
+    /// The name of the function or expression called inlined.
+    ///
+    /// This property returns the complete call expression trimming arguments, closures body and newlines.
+    /// ```swift
+    /// func function() {
+    ///     firstCall()
+    ///     reference.secondCall()
+    ///     anotherFunction().filter { $0 > $ 1 }
+    ///         .map(\.name)
+    ///         .doSomething { }
+    /// }
+    /// ```
+    ///
+    /// The resulting `inlineCallExpression` for all three function calls above would:
+    ///  - 1. firstCall
+    ///  - 2. reference.secondCall
+    ///  - 3. anotherFunction.filter.map.doSomething
+    public var inlineCallExpression: String {
+        tokens.map(\.value).joined(separator: ".")
+    }
+        
     /// The arguments passed to the function call.
     ///
     /// This property returns an array of ``Argument``, each representing an argument passed to the function.
@@ -63,11 +115,29 @@ public struct FunctionCall: DeclarationDecoration, SyntaxNodeProviding {
         Closure(node: node.trailingClosure)
     }
     
+    /// The additional trailing closure of the function call, if any.
+    public var additionalClosures: [Closure] {
+        node.additionalTrailingClosures.compactMap { Closure(node: $0.closure) }
+    }
+    
     /// - Returns: if the given function call is a trailing closure.
     public var isClosure: Bool {
         closure != nil
     }
-
+    
+    /// - Returns: true if the given function call refers to self.
+    public var isSelfReference: Bool {
+        node.calledExpression.as(MemberAccessExprSyntax.self)?.base?.trimmedDescription == "self"
+    }
+    
+    /// - Returns: true if the given function call has a closure with self reference.
+    public var hasClosureWithSelfReference: Bool {
+        let hasSelfRefInClosure = closure?.hasSelfReference ?? false
+        let hasSelfRefInAdditionalClosure = additionalClosures.contains(where: \.hasSelfReference)
+        let hasSelfRefInInlineCalls = internalInlineCalls.contains(where: \.hasClosureWithSelfReference)
+        return hasSelfRefInClosure || hasSelfRefInAdditionalClosure || hasSelfRefInInlineCalls
+    }
+    
     public var tokens: [Token] {
         return node.tokens(viewMode: .all)
             .compactMap { token in
@@ -98,9 +168,13 @@ public struct FunctionCall: DeclarationDecoration, SyntaxNodeProviding {
     internal init(node: FunctionCallExprSyntax) {
         self.node = node
     }
+    
+    private var internalInlineCalls: [FunctionCall] {
+        FunctionCall.parseInline(node: node)
+    }
 }
 
-// MARK: - Argument
+// MARK: - Call, Argument, Token
 
 public extension FunctionCall {
     /// A struct representing a single argument in a function call.
@@ -139,7 +213,26 @@ public extension FunctionCall {
 // MARK: Capabilities Comformance
 
 extension FunctionCall: FunctionCallsProviding {
+    /// An array of function calls present in this function call if it has a trailing closure.
     public var functionCalls: [FunctionCall] {
         closure?.functionCalls ?? []
+    }
+    
+    private static func parseInline(node: FunctionCallExprSyntax) -> [FunctionCall] {
+        var results: [FunctionCall] = []
+        
+        func traverse(node: ExprSyntax?) {
+            guard let node = node else { return }
+                
+            if let funcCall = node.as(FunctionCallExprSyntax.self) {
+                results.append(FunctionCall(node: funcCall))
+                traverse(node: funcCall.calledExpression)
+            } else if let memberAccessExpr = node.as(MemberAccessExprSyntax.self) {
+                traverse(node: memberAccessExpr.base)
+            }
+        }
+        
+        traverse(node: node.calledExpression)
+        return results.reversed()
     }
 }

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/FunctionCall.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/FunctionCall.swift
@@ -60,7 +60,7 @@ public struct FunctionCall: DeclarationDecoration, SyntaxNodeProviding {
     /// Returns all closures present in this function call if it is an inlined function call expression, or its single closure if any.
     /// This will return empty if this function has no trailing closure at all.
     public var inlineClosures: [Closure] {
-        (internalInlineCalls.map(\.closure) + [closure]).compactMap(\.self)
+        (internalInlineCalls.map(\.closure) + [closure]).compactMap { $0 }
     }
     
     /// The name of the function or expression called inlined.

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Guard.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Guard.swift
@@ -1,5 +1,5 @@
 //
-//  If.swift
+//  Guard.swift
 //  Harmonize
 //
 //  Copyright 2024 Perry Street Software Inc.
@@ -20,34 +20,28 @@
 import Foundation
 import SwiftSyntax
 
-public struct If: DeclarationDecoration, SyntaxNodeProviding {
-    public let node: IfExprSyntax
+/// A struct that represents a `guard` statement in Swift code.
+public struct Guard: DeclarationDecoration, SyntaxNodeProviding {
+    /// The syntax node representing the guard statement in the abstract syntax tree (AST).
+    public let node: GuardStmtSyntax
 
     public var description: String {
         node.trimmedDescription
     }
         
-    public var elseIf: If? {
-        Self(node: node.elseBody?.as(IfExprSyntax.self))
-    }
-    
-    public var `else`: Else? {
-        Else(node: node.elseBody?.as(CodeBlockSyntax.self))
-    }
-    
-    internal init(node: IfExprSyntax) {
+    internal init(node: GuardStmtSyntax) {
         self.node = node
     }
     
-    internal init?(node: IfExprSyntax?) {
+    internal init?(node: GuardStmtSyntax?) {
         guard let node else { return nil }
         self.node = node
     }
 }
 
-// MARK: Providers comformance
+// MARK: BodyProviding comformance
 
-extension If: BodyProviding, ConditionsProviding {
+extension Guard: BodyProviding, ConditionsProviding {
     public var body: Body? {
         Body(node: node.body.statements)
     }

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/InfixExpression.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/InfixExpression.swift
@@ -1,5 +1,5 @@
 //
-//  Assignment.swift
+//  InfixExpression.swift
 //  Harmonize
 //
 //  Copyright 2024 Perry Street Software Inc.
@@ -20,14 +20,18 @@
 import Foundation
 import SwiftSyntax
 
-/// Represents an assignment expression in Swift syntax, specifically an infix operator assignment (e.g., `a = b`).
-public struct Assignment: DeclarationDecoration, SyntaxNodeProviding {
+/// Represents an infix expression in Swift syntax (e.g., `a = b`).
+public struct InfixExpression: DeclarationDecoration, SyntaxNodeProviding {
     /// The underlying syntax node for the assignment expression.
     public let node: InfixOperatorExprSyntax
     
     /// The target of the assignment expression (the left operand).
     public var leftOperand: String {
         node.leftOperand.trimmedDescription
+    }
+    
+    public var `operator`: String {
+        node.operator.trimmedDescription
     }
     
     /// the assignment value after `=` (the right operand)
@@ -60,6 +64,10 @@ public struct Assignment: DeclarationDecoration, SyntaxNodeProviding {
         return .unsupported(node.rightOperand.trimmedDescription)
     }
     
+    public var isAssignment: Bool {
+        `operator` == "="
+    }
+    
     public var description: String {
         node.trimmedDescription
     }
@@ -69,9 +77,9 @@ public struct Assignment: DeclarationDecoration, SyntaxNodeProviding {
     }
 }
 
-// MARK: Operands
+// MARK: InfixExpression + Operands
 
-extension Assignment {
+extension InfixExpression {
     public enum RightOperand {
         case reference(name: String, arguments: [String])
         case literalStringValue(String)

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/InitializerClause.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/InitializerClause.swift
@@ -26,6 +26,10 @@ public struct InitializerClause: DeclarationDecoration, SyntaxNodeProviding {
     /// The syntax node representing the initializer clause in the abstract syntax tree (AST).
     public let node: InitializerClauseSyntax
     
+    public var description: String {
+        node.trimmedDescription
+    }
+    
     /// The value of the initializer clause, representing the content assigned after the `=` sign.
     ///
     /// For example, in the declaration `var prop = "xyz"`, the `value` is `"xyz"`.
@@ -34,8 +38,11 @@ public struct InitializerClause: DeclarationDecoration, SyntaxNodeProviding {
         return literalValue ?? node.value.trimmedDescription
     }
     
-    public var description: String {
-        node.trimmedDescription
+    /// A bool that indicates if this initializer's value is a self reference, such as in `if let self = self`
+    ///
+    /// - Returns: true if this initializer is a self reference.
+    public var isSelfReference: Bool {
+        node.value.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind == .keyword(.`self`)
     }
     
     internal init(node: InitializerClauseSyntax) {

--- a/Sources/HarmonizeSemantics/GrammarComponents/Provider/BodyProviding.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Provider/BodyProviding.swift
@@ -35,56 +35,89 @@ extension BodyProviding {
     /// - Parameter variableName: The name of the variable to check for.
     /// - Returns: `true` if the body contains an assignment to the variable, otherwise `false`.
     public func assigns(to variableName: String) -> Bool {
-        body?.assignments.contains { $0.leftOperand == variableName } ?? false
+        body?.infixExpressions.filter(\.isAssignment)
+            .contains { $0.leftOperand.contains(variableName) } ?? false
     }
     
     /// Retrieves all assignments to the specified variable name.
     ///
     /// - Parameter variableName: The name of the variable.
     /// - Returns: An array of assignments to the specified variable, or an empty array if none exist.
-    public func assignments(to variableName: String) -> [Assignment] {
-        body?.assignments.filter { $0.leftOperand == variableName } ?? []
+    public func assignments(to variableName: String) -> [InfixExpression] {
+        body?.infixExpressions.filter(\.isAssignment)
+            .filter { $0.leftOperand == variableName } ?? []
     }
     
     /// Checks if the body contains any assignments.
     ///
     /// - Returns: `true` if the body contains assignments, otherwise `false`.
     public func hasAssignments() -> Bool {
-        body?.assignments.isEmpty == false
+        body?.infixExpressions.filter(\.isAssignment).isEmpty == false
     }
-        
+     
+    // - MARK: Common Checks
+    
     /// Checks if the body contains any `if` statements.
     ///
     /// - Returns: `true` if the body contains `if` statements, otherwise `false`.
-    public func hasIfStatements() -> Bool {
+    public func hasIfs() -> Bool {
         body?.ifs.isEmpty == false
     }
     
     /// Retrieves all `if` statements in the body.
     ///
-    /// - Returns: An array of `If` objects representing all `if` statements, or an empty array if none exist.
-    public func ifStatements() -> [If] {
+    /// - Returns: An array of ``If`` objects representing all `if` statements, or an empty array if none exist.
+    public func ifs() -> [If] {
         body?.ifs ?? []
     }
         
     /// Checks if the body contains any `switch` statements.
     ///
     /// - Returns: `true` if the body contains `switch` statements, otherwise `false`.
-    public func hasSwitchStatements() -> Bool {
+    public func hasSwitches() -> Bool {
         body?.switches.isEmpty == false
     }
     
     /// Retrieves all `switch` statements in the body.
     ///
     /// - Returns: An array of `Switch` objects representing all `switch` statements, or an empty array if none exist.
-    public func switchStatements() -> [Switch] {
+    public func switches() -> [Switch] {
         body?.switches ?? []
+    }
+    
+    /// Retrieves all `guard` statements in the body.
+    ///
+    /// - Returns: An array of `Guard` objects representing all `guard` statements, or an empty array if none exist.
+    public func guards() -> [Guard] {
+        body?.guards ?? []
+    }
+    
+    /// Retrieves all closure statements in this body.
+    ///
+    /// - Returns: An array of `Closure` objects representing all `switch` statements, or an empty array if none exist.
+    public func closures() -> [Closure] {
+        body?.closures ?? []
     }
     
     /// Checks if the body is empty.
     ///
     /// - Returns: `true` if the body is empty, otherwise `false`.
     public func isEmptyBody() -> Bool {
-        return self.body?.description.isEmpty ?? true
+        return body?.description.isEmpty ?? true
+    }
+    
+    /// Checks if any statement in this body is a self reference
+    /// This doesn't necessarily means that this body is having a self reference within a closure since this could be a simple reference in a function call.
+    ///
+    /// - Returns: A boolean value indicating whether any of the statement in this body has a self reference.
+    public var refersToSelf: Bool {
+        return body?.hasAnySelfReference ?? false
+    }
+    
+    /// Checks if any closure in this body has a self reference.
+    ///
+    /// - Returns: A boolean value indicating whether any of the statement in this body has a self reference.
+    public var hasAnyClosureWithSelfReference: Bool {
+        return body?.hasAnyClosureWithSelfReference ?? false
     }
 }

--- a/Sources/HarmonizeSemantics/GrammarComponents/Provider/ConditionsProviding.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Provider/ConditionsProviding.swift
@@ -1,0 +1,33 @@
+//
+//  ConditionsProviding.swift
+//  Harmonize
+//
+//  Copyright 2024 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+/// A protocol that represents declarations capable of providing an array of conditions.
+public protocol ConditionsProviding {
+    var conditions: [Condition] { get }
+}
+
+public extension ConditionsProviding {
+    /// A boolean that indicates if there is a optional binding to self in this statement.
+    ///
+    /// Commonly used in `guard let self` to hold a strong reference to self
+    /// in which can be combined with `weak self` capturing in a ``Closure``.
+    var isBindingToSelf: Bool {
+        conditions.contains(where: \.isBindingToSelf)
+    }
+}

--- a/Sources/HarmonizeSemantics/GrammarComponents/Provider/FunctionCallsProviding.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Provider/FunctionCallsProviding.swift
@@ -43,9 +43,13 @@ public extension FunctionCallsProviding {
     /// - Parameter functions: An array of function names to check.
     /// - Parameter recursively: A Boolean indicating whether to check nested invocations. Default is `false`.
     /// - Returns: A Boolean value indicating whether any of the functions in the list have been invoked.
-    func invokes(_ functions: [String], recursively: Bool = false) -> Bool {
-        let calls = recursively ? functionCalls.flatten : functionCalls
-        return calls.contains(where: { functions.contains($0.call) })
+    func invokes(_ functions: [String], includeClosures: Bool = false) -> Bool {
+        let calls = includeClosures ? functionCalls.flatten : functionCalls
+        return calls.contains { funcCall in
+            functions.contains { invocation in
+                invocation.contains(funcCall.call)
+            }
+        }
     }
 
     /// Checks if a specific function name has been invoked.
@@ -53,8 +57,8 @@ public extension FunctionCallsProviding {
     /// - Parameter function: The name of the function to check.
     /// - Parameter recursively: A Boolean indicating whether to check nested invocations. Default is `false`.
     /// - Returns: A Boolean value indicating whether the specified function has been invoked.
-    func invokes(_ function: String, recursively: Bool = false) -> Bool {
-        return invokes([function], recursively: recursively)
+    func invokes(_ function: String, includeClosures: Bool = false) -> Bool {
+        return invokes([function], includeClosures: includeClosures)
     }
 
     /// Checks if any function call satisfies a given predicate, optionally checking recursively.
@@ -62,8 +66,8 @@ public extension FunctionCallsProviding {
     /// - Parameter predicate: A closure that takes a ``FunctionCall`` object and returns a Boolean value.
     /// - Parameter recursively: If set to `true` it will traverse all function calls including nested for the given predicate.
     /// - Returns: A Boolean value indicating whether any function call satisfies the given predicate.
-    func invokes(where predicate: (FunctionCall) -> Bool, recursively: Bool = false) -> Bool {
-        let calls = recursively ? functionCalls.flatten : functionCalls
+    func invokes(where predicate: (FunctionCall) -> Bool, includeClosures: Bool = false) -> Bool {
+        let calls = includeClosures ? functionCalls.flatten : functionCalls
         return calls.contains(where: predicate)
     }
 }

--- a/Tests/HarmonizeTests/Tests/Filters/FunctionCallTests.swift
+++ b/Tests/HarmonizeTests/Tests/Filters/FunctionCallTests.swift
@@ -22,15 +22,15 @@ final class FunctionCallTests: XCTestCase {
             }
     }
     
-    func testFunctionCallInvokesRecursively() {
+    func testFunctionCallInvokesIncludingClosures() {
         // e.g every `describe` must call `TestFactory().withValue(1)` on its `beforeEach`
         // so `invokes` must be able to do a nested check here.
         sampleCode.classes()
             .functions()
             .withName("spec")
             .assertTrue {
-                $0.invokes("TestFactory().withValue", recursively: true) &&
-                $0.invokes("something.onTap", recursively: true)
+                $0.invokes("TestFactory().withValue", includeClosures: true) &&
+                $0.invokes("something.onTap", includeClosures: true)
             }
     }
 }

--- a/Tests/SemanticsTests/ClosureTests.swift
+++ b/Tests/SemanticsTests/ClosureTests.swift
@@ -1,0 +1,84 @@
+//
+//  ClosureTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import HarmonizeSemantics
+import XCTest
+import SwiftSyntax
+
+final class ClosuresTests: XCTestCase {
+    private var sourceSyntax = """
+    public final class Klass {
+        private var name: String = ""
+    
+        public func call() {
+            execute { param in self.name.doSomething(param) }
+    
+            execute { [weak self] param in
+                self.name.doSomething(param)
+            }
+    
+            execute { [unowned self] param in self.name.doSomething(param) }
+    
+            executeWithReturnValue { param -> Bool in param.contains("true") }
+        }
+    }
+    """.parsed()
+    
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
+    
+    override func setUp() {
+        visitor.walk(sourceSyntax)
+    }
+    
+    func testParsesClosures() throws {
+        let function = visitor.classes.first!.functions.first!
+        XCTAssertTrue(function.functionCalls.allSatisfy(\.isClosure))
+    }
+    
+    func testParsesClosuresParameters() throws {
+        let function = visitor.classes.first!.functions.first!
+        XCTAssertEqual(
+            ["param", "param", "param", "param"],
+            function.functionCalls.compactMap(\.closure).flatMap(\.parameters)
+        )
+    }
+    
+    func testParsesClosuresReturnClause() throws {
+        let function = visitor.classes.first!.functions.first!
+        XCTAssertEqual(
+            [String(describing: Bool.self)],
+            function.functionCalls
+                .compactMap { $0.closure?.returnClause?.typeAnnotation?.annotation }
+        )
+    }
+    
+    func testParsesIfClosuresHasSelfReferences() throws {
+        let function = visitor.classes.first!.functions.first!
+        XCTAssertTrue(
+            function.functionCalls[0...2].allSatisfy { $0.closure?.hasSelfReference ?? false }
+        )
+    }
+    
+    func testParsesCaptures() throws {
+        let function = visitor.classes.first!.functions.first!
+        let closures = function.functionCalls.compactMap(\.closure)
+        
+        let capturesSelf = closures.contains { $0.isCapturing(valueOf: "self") }
+        let capturesWeakSelf = closures.contains { $0.isCapturingWeak(valueOf: "self") }
+        let capturesUnownedSelf = closures.contains { $0.isCapturingUnowned(valueOf: "self") }
+        
+        XCTAssertTrue(capturesSelf && capturesWeakSelf && capturesUnownedSelf)
+    }
+}

--- a/Tests/SemanticsTests/GuardTests.swift
+++ b/Tests/SemanticsTests/GuardTests.swift
@@ -1,0 +1,71 @@
+//
+//  GuardTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import HarmonizeSemantics
+import XCTest
+import SwiftSyntax
+
+final class GuardTests: XCTestCase {
+    private var sourceSyntax = """
+    public final class Klass {
+        private var name: String = ""
+        private var optional: String? = nil
+    
+        public func call() {
+            guard !name.isEmpty else { 
+                printError()
+                return
+            }
+    
+            closure { [weak self] in 
+                guard let self else { return }
+            }
+        }
+    }
+    """.parsed()
+    
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
+    
+    override func setUp() {
+        visitor.walk(sourceSyntax)
+    }
+    
+    func testParsesGuards() throws {
+        let function = visitor.classes.first!.functions.first!
+        XCTAssertTrue(function.guards().count == 1)
+    }
+    
+    func testParsesGuardConditions() throws {
+        let function = visitor.classes.first!.functions.first!
+        let guarde = function.guards().first!
+        
+        XCTAssertTrue(guarde.conditions[0].isBooleanExpression)
+    }
+    
+    func testParsesGuardElseBody() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `guard` = function.guards().first!
+        
+        XCTAssertTrue(`guard`.body?.functionCalls.count == 1)
+    }
+    
+    func testParsesGuardBinding() throws {
+        let function = visitor.classes.first!.functions.first!
+        let closure = function.functionCalls.first!.closure!
+        
+        XCTAssertTrue(closure.hasSelfReference)
+        XCTAssertTrue(closure.guards().first!.conditions[0].isBindingToSelf)
+    }
+}

--- a/Tests/SemanticsTests/IfTests.swift
+++ b/Tests/SemanticsTests/IfTests.swift
@@ -1,0 +1,99 @@
+//
+//  IfTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import HarmonizeSemantics
+import XCTest
+import SwiftSyntax
+
+final class IfTests: XCTestCase {
+    private var sourceSyntax = """
+    public final class Klass {
+        private var name: String = ""
+        private var optional: String? = nil
+    
+        public func call() {
+            if name.isEmpty {
+                printError()
+            } else if name.count { $0.isLetter } > 10 {
+                self.anotherCall()
+            } else {
+                self.execute()
+            }
+    
+            if let optional {
+                self.execute()
+            }
+    
+            closure { [weak self] in 
+                if let self = self {
+                
+                }
+            }
+        }
+    
+        public func anotherCall() {}
+        public func execute() {}
+    }
+    """.parsed()
+    
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
+    
+    override func setUp() {
+        visitor.walk(sourceSyntax)
+    }
+    
+    func testParsesIfs() throws {
+        let function = visitor.classes.first!.functions.first!
+        XCTAssertTrue(function.ifs().count == 2)
+    }
+    
+    func testParsesIfsConditions() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `if` = function.ifs().first!
+        XCTAssertTrue(`if`.conditions[0].isBooleanExpression)
+    }
+    
+    func testParsesElseIf() throws {
+        let function = visitor.classes.first!.functions.first!
+        let elseIf = function.ifs().first!.elseIf!
+        
+        XCTAssertTrue(elseIf.conditions[0].isComparison == true)
+        XCTAssertTrue(elseIf.functionCalls.count == 1)
+    }
+    
+    func testParsesElse() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `else` = function.ifs().first!.elseIf!.else!
+        
+        XCTAssertTrue(`else`.functionCalls.count == 1)
+    }
+    
+    func testParsesOptionalBinding() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `if` = function.ifs()[1]
+        
+        XCTAssertTrue(!`if`.isBindingToSelf)
+        XCTAssertTrue(`if`.conditions.first!.isOptionalBinding)
+    }
+    
+    func testParsesBindingToSelf() throws {
+        let function = visitor.classes.first!.functions.first!
+        let closure = function.functionCalls.first { $0.isClosure }!.closure!
+        
+        let `if` = closure.ifs()[0]
+        
+        XCTAssertTrue(`if`.isBindingToSelf)
+    }
+}

--- a/Tests/SemanticsTests/InitializersTests.swift
+++ b/Tests/SemanticsTests/InitializersTests.swift
@@ -128,9 +128,9 @@ final class InitializersTests: XCTestCase {
     func testParseFunctionBody() throws {
         let body = visitor.structs.flatMap(\.initializers).first!.body!
         let statements = body.statements
-        let assignment = body.assignments.first!
+        let infixExpression = body.infixExpressions.first!
         
         XCTAssertEqual(statements.map(\.description), ["self.property = property", "var _ = \"bar\""])
-        XCTAssertEqual(assignment.leftOperand, "self.property")
+        XCTAssertEqual(infixExpression.leftOperand, "self.property")
     }
 }

--- a/Tests/SemanticsTests/SwitchTests.swift
+++ b/Tests/SemanticsTests/SwitchTests.swift
@@ -1,0 +1,96 @@
+//
+//  SwitchTests.swift
+//  Harmonize
+//
+//  Copyright (c) Perry Street Software 2024. All Rights Reserved.
+//
+
+import Foundation
+import HarmonizeSemantics
+import XCTest
+import SwiftSyntax
+
+final class SwitchTests: XCTestCase {
+    private var sourceSyntax = """
+    public final class ViewController {
+        private var state: ViewState = .loading
+        private var handler: Handler = UiViewHandler()
+    
+        public func onViewAppear() {
+            switch state {
+            case .loading:
+                self.showLoading()
+            case .success:
+                handler.post {
+                    self.hideLoading()
+                }
+            }
+        }
+    
+        public func safeOnViewAppear() {
+            switch state {
+            case .loading:
+                self.showLoading()
+            case .success:
+                self.hideLoading()
+            }
+        }
+    
+        public func hideLoading() {}
+        public func showLoading() {}
+    }
+    """.parsed()
+    
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
+    
+    override func setUp() {
+        visitor.walk(sourceSyntax)
+    }
+    
+    func testParsesSwitch() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `switch` = function.switches().first!
+        XCTAssertTrue(`switch`.cases.count == 2)
+    }
+    
+    func testParsesSwitchCases() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `switch` = function.switches().first!
+        let cases = `switch`.cases
+        
+        let items = cases.flatMap(\.items).compactMap {
+            if case .literalExpression(let member) = $0 {
+                return member
+            }
+            
+            return nil
+        }
+        
+        XCTAssertTrue(items.count == 2)
+        XCTAssertEqual(
+            [".loading", ".success"],
+            items
+        )
+    }
+    
+    func testParsesSwitchCasesWithSelfReference() throws {
+        let function = visitor.classes.first!.functions.first!
+        let `switch` = function.switches().first!
+        
+        XCTAssertTrue(`switch`.hasAnyClosureWithSelfReference)
+    }
+    
+    func testParsesSwitchCasesWithNoSelfReference() throws {
+        let function = visitor.classes.first!.functions[1]
+        let `switch` = function.switches().first!
+        
+        XCTAssertFalse(`switch`.hasAnyClosureWithSelfReference)
+    }
+}

--- a/Tests/SemanticsTests/VariablesTests.swift
+++ b/Tests/SemanticsTests/VariablesTests.swift
@@ -180,7 +180,7 @@ final class VariablesTests: XCTestCase {
 
         XCTAssertEqual(bodies[0].functionCalls.count, 1)
         XCTAssertEqual(bodies[0].statements.count, 2)
-        XCTAssertEqual(bodies[1].assignments.count, 1)
+        XCTAssertEqual(bodies[1].infixExpressions.count, 1)
     }
 
     func testParseVariablesGetterBody() throws {


### PR DESCRIPTION
- Rework function calls to support parsing inline functions calls, like:
```swift
variable.doSomething().map { }.filter { }.sink {}
```

The above code was never supported and were breaking the possibility of writing lint rules to catch weak self in closures, for example. This is now possible:

```swift
 Harmonize.productionCode().on("ViewModels")
        .functions()
        .filter(\.hasAnyClosureWithSelfReference)
       .assertTrue(message: "Closures with self reference should use weak self") {
           $0.closures().allSatisfy { $0.isCapturingWeak(valueOf: "self") }
       }
```

- Added `Condition` component
- Added `Guard` component
- Renamed `Assignment` to `InfixExpression`
- Added `Else` component
- Better `If`, `Guard` modelling
- Better and new `Body` functions
- Renamed some methods so they are better aligned with the API