### PR TITLE
Update swift-syntax pointings to 601.0.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,12 +1,13 @@
 {
+  "originHash" : "b1163de60a620ee671dc9a709ea617fb1b6d6ba89ad8a32c0aa2dc60ab7495d5",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "64889f0c732f210a935a0ad7cda38f77f876262d",
-        "version" : "509.1.1"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     },
     {
@@ -19,5 +20,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "b1163de60a620ee671dc9a709ea617fb1b6d6ba89ad8a32c0aa2dc60ab7495d5",
   "pins" : [
     {
       "identity" : "swift-syntax",
@@ -15,10 +14,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/Yams.git",
       "state" : {
-        "revision" : "3036ba9d69cf1fd04d433527bc339dc0dc75433d",
-        "version" : "5.1.3"
+        "revision" : "3d6871d5b4a5cd519adf233fbb576e0a2af71c17",
+        "version" : "5.4.0"
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .library(name: "HarmonizeUtils", targets: ["HarmonizeUtils"])
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "509.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "601.0.1"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.3")
     ],
     targets: [

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Closure.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Closure.swift
@@ -140,7 +140,7 @@ extension Closure {
         
         /// The text representation of the captured value.
         public var value: String {
-            node.expression.trimmedDescription
+            node.initializer?.value.trimmedDescription ?? ""
         }
         
         internal init(node: ClosureCaptureSyntax) {

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Closure.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Closure.swift
@@ -58,15 +58,15 @@ public struct Closure: DeclarationDecoration, SyntaxNodeProviding {
     }
     
     public func isCapturing(valueOf value: String) -> Bool {
-        return captures.contains(where: { $0.value == value })
+        return captures.contains(where: { $0.node.name.text == value })
     }
     
     public func isCapturingWeak(valueOf value: String) -> Bool {
-        return captures.contains(where: { $0.isWeak() && $0.value == value })
+        return captures.contains(where: { $0.isWeak() && $0.node.name.text == value })
     }
     
     public func isCapturingUnowned(valueOf value: String) -> Bool {
-        return captures.contains(where: { $0.isUnowned() && $0.value == value })
+        return captures.contains(where: { $0.isUnowned() && $0.node.name.text == value })
     }
     
     internal init(node: ClosureExprSyntax) {

--- a/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Condition.swift
+++ b/Sources/HarmonizeSemantics/GrammarComponents/Decoration/Condition.swift
@@ -147,7 +147,7 @@ extension Condition {
         ///
         /// This property extracts the name of the variable being bound in the optional binding, such as `"abc"` in `guard let abc = ...`.
         public var name: String {
-            if let identifier = node.as(IdentifierPatternSyntax.self) {
+            if let identifier = node.pattern.as(IdentifierPatternSyntax.self) {
                 return identifier.identifier.text
             }
             


### PR DESCRIPTION
Update the `swift-syntax` pointings to the latest stable version `601.0.1`.

I fixed a couple of warnings and did a few updates so the tests would pass.