### PR TITLE
Fix crash in DeclarationsCache.supertype(of:)

### DIFF
--- a/Sources/HarmonizeSemantics/Collector/Cache/DeclarationsCache.swift
+++ b/Sources/HarmonizeSemantics/Collector/Cache/DeclarationsCache.swift
@@ -51,24 +51,45 @@ internal class DeclarationsCache {
     }
     
     func supertype(of subtype: String) -> String? {
-        let matches = typeInheritanceCache.compactMap {
-            $0.value.contains(subtype) ? $0.key : nil
-        }
+        let cacheCopy = locking { typeInheritanceCache }
+        return findSupertype(of: subtype, in: cacheCopy, visited: [])
+    }
+
+    private func findSupertype(
+        of subtype: String,
+        in cache: [String: [String]],
+        visited: Set<String>
+    ) -> String? {
+        guard !visited.contains(subtype) else { return nil }
+
+        let matches = cache.compactMap { $0.value.contains(subtype) ? $0.key : nil }
 
         guard let directSupertype = matches.first else {
             return nil
         }
 
+        var visited = visited
+        visited.insert(subtype)
+
         if matches.count == 1 {
-            return supertype(of: directSupertype) ?? directSupertype
+            return findSupertype(
+                of: directSupertype,
+                in: cache,
+                visited: visited
+            ) ?? directSupertype
         }
-        
-        let firstSupertype = matches.first { supertype in
-            typeInheritanceCache.keys.contains(supertype)
+
+        let firstSupertype = matches.first { type in
+            cache.keys.contains(type)
         }
-        
+
         guard let firstSupertype else { return directSupertype }
-        return supertype(of: firstSupertype) ?? firstSupertype
+
+        return findSupertype(
+            of: firstSupertype,
+            in: cache,
+            visited: visited
+        ) ?? firstSupertype
     }
     
     func put(subtype typeName: String, of type: String) {

--- a/Sources/HarmonizeSemantics/Collector/Cache/DeclarationsCache.swift
+++ b/Sources/HarmonizeSemantics/Collector/Cache/DeclarationsCache.swift
@@ -54,6 +54,16 @@ internal class DeclarationsCache {
         let cacheCopy = locking { typeInheritanceCache }
         return findSupertype(of: subtype, in: cacheCopy, visited: [])
     }
+    
+    func put(subtype typeName: String, of type: String) {
+        locking {
+            var values = typeInheritanceCache[type, default: []]
+            if !values.contains(typeName) {
+                values.append(typeName)
+            }
+            typeInheritanceCache[type] = values
+        }
+    }
 
     private func findSupertype(
         of subtype: String,
@@ -72,36 +82,48 @@ internal class DeclarationsCache {
         visited.insert(subtype)
 
         if matches.count == 1 {
-            return findSupertype(
+            let resolved = findSupertype(
                 of: directSupertype,
                 in: cache,
                 visited: visited
-            ) ?? directSupertype
+            )
+
+            return resolvedSupertype(
+                resolved ?? directSupertype,
+                visited: visited
+            )
         }
 
         let firstSupertype = matches.first { type in
-            cache.keys.contains(type)
+            cache[type] != nil
         }
 
-        guard let firstSupertype else { return directSupertype }
+        guard let firstSupertype else {
+            return resolvedSupertype(
+                directSupertype,
+                visited: visited
+            )
+        }
 
-        return findSupertype(
+        let resolved = findSupertype(
             of: firstSupertype,
             in: cache,
             visited: visited
-        ) ?? firstSupertype
+        )
+
+        return resolvedSupertype(
+            resolved ?? firstSupertype,
+            visited: visited
+        )
     }
-    
-    func put(subtype typeName: String, of type: String) {
-        locking {
-            var values = typeInheritanceCache[type, default: []]
-            if !values.contains(typeName) {
-                values.append(typeName)
-            }
-            typeInheritanceCache[type] = values
-        }
+
+    private func resolvedSupertype(
+        _ candidate: String,
+        visited: Set<String>
+    ) -> String? {
+        visited.contains(candidate) ? nil : candidate
     }
-    
+
     private func locking<T>(f: () -> T) -> T {
         lock.lock()
         defer { lock.unlock() }

--- a/Tests/SemanticsTests/DeclarationsCacheTests.swift
+++ b/Tests/SemanticsTests/DeclarationsCacheTests.swift
@@ -1,0 +1,59 @@
+//
+//  DeclarationsCacheTests.swift
+//  Harmonize
+//
+//  Copyright 2026 Perry Street Software Inc.
+
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+
+//  http://www.apache.org/licenses/LICENSE-2.0
+
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import HarmonizeSemantics
+import XCTest
+
+/// Regression tests for the crash in `DeclarationsCache.supertype(of:)`.
+final class DeclarationsCacheTests: XCTestCase {
+    // MARK: - Circular inheritance
+
+    /// Old code: `supertype(of:)` recurses A -->B -->A -->... until stack overflow.
+    /// Fixed code: `visited` set breaks the cycle; the call terminates and returns a value.
+    func testSupertypeOfDoesNotCrashOnCircularInheritance() {
+        let cache = DeclarationsCache.shared
+
+        // Simulate a circular inheritance graph in the cache:
+        //   CycleA_DCTest inherits CycleB_DCTest
+        //   CycleB_DCTest inherits CycleA_DCTest
+        cache.put(subtype: "CycleA_DCTest", of: "CycleB_DCTest")
+        cache.put(subtype: "CycleB_DCTest", of: "CycleA_DCTest")
+
+        // Old code --> infinite recursion → stack overflow --> crash.
+        // Fixed code --> `visited` set detects the cycle; the call returns without crashing.
+        // The assertion is simply that this line is reached at all.
+        _ = cache.supertype(of: "CycleA_DCTest")
+    }
+
+    // MARK: - Concurrent access
+
+    /// Old code: reads `typeInheritanceCache` without the lock --> data race.
+    /// Reliably detected by the Swift Thread Sanitizer (-sanitize=thread).
+    /// Fixed code: takes a snapshot of the cache under the lock --> no data race.
+    func testConcurrentReadsAndWritesDoNotCrash() {
+        let cache = DeclarationsCache.shared
+
+        // Interleave writes (put) and reads (supertype) across many threads simultaneously.
+        // On old code + TSan this reliably triggers the data race and crashes.
+        DispatchQueue.concurrentPerform(iterations: 200) { i in
+            cache.put(subtype: "Concurrent\(i)_Child_DCTest", of: "Concurrent\(i)_Parent_DCTest")
+            _ = cache.supertype(of: "Concurrent\(i)_Child_DCTest")
+        }
+    }
+}

--- a/Tests/SemanticsTests/DeclarationsCacheTests.swift
+++ b/Tests/SemanticsTests/DeclarationsCacheTests.swift
@@ -22,38 +22,28 @@ import XCTest
 
 /// Regression tests for the crash in `DeclarationsCache.supertype(of:)`.
 final class DeclarationsCacheTests: XCTestCase {
-    // MARK: - Circular inheritance
+    private var sourceSyntax = """
+    class CycleA_DCTest: CycleB_DCTest {}
+    class CycleB_DCTest: CycleA_DCTest {}
+    """.parsed()
 
-    /// Old code: `supertype(of:)` recurses A -->B -->A -->... until stack overflow.
-    /// Fixed code: `visited` set breaks the cycle; the call terminates and returns a value.
-    func testSupertypeOfDoesNotCrashOnCircularInheritance() {
-        let cache = DeclarationsCache.shared
+    private lazy var visitor = {
+        DeclarationsCollector(
+            sourceCodeLocation: SourceCodeLocation(
+                sourceFilePath: nil,
+                sourceFileTree: sourceSyntax
+            )
+        )
+    }()
 
-        // Simulate a circular inheritance graph in the cache:
-        //   CycleA_DCTest inherits CycleB_DCTest
-        //   CycleB_DCTest inherits CycleA_DCTest
-        cache.put(subtype: "CycleA_DCTest", of: "CycleB_DCTest")
-        cache.put(subtype: "CycleB_DCTest", of: "CycleA_DCTest")
-
-        // Old code --> infinite recursion → stack overflow --> crash.
-        // Fixed code --> `visited` set detects the cycle; the call returns without crashing.
-        // The assertion is simply that this line is reached at all.
-        _ = cache.supertype(of: "CycleA_DCTest")
+    override func setUp() {
+        visitor.walk(sourceSyntax)
     }
 
-    // MARK: - Concurrent access
-
-    /// Old code: reads `typeInheritanceCache` without the lock --> data race.
-    /// Reliably detected by the Swift Thread Sanitizer (-sanitize=thread).
-    /// Fixed code: takes a snapshot of the cache under the lock --> no data race.
-    func testConcurrentReadsAndWritesDoNotCrash() {
-        let cache = DeclarationsCache.shared
-
-        // Interleave writes (put) and reads (supertype) across many threads simultaneously.
-        // On old code + TSan this reliably triggers the data race and crashes.
-        DispatchQueue.concurrentPerform(iterations: 200) { i in
-            cache.put(subtype: "Concurrent\(i)_Child_DCTest", of: "Concurrent\(i)_Parent_DCTest")
-            _ = cache.supertype(of: "Concurrent\(i)_Child_DCTest")
-        }
+    func testSupertypeOfDoesNotCrashOnCircularInheritance() {
+        let classes = visitor.classes
+        XCTAssertEqual(classes.map(\.name), ["CycleA_DCTest", "CycleB_DCTest"])
+        XCTAssertEqual(classes.first!.inheritanceTypesNames, ["CycleB_DCTest"])
+        XCTAssertEqual(classes.last!.inheritanceTypesNames, ["CycleA_DCTest"])
     }
 }

--- a/Tests/SemanticsTests/DeclarationsCacheTests.swift
+++ b/Tests/SemanticsTests/DeclarationsCacheTests.swift
@@ -45,5 +45,9 @@ final class DeclarationsCacheTests: XCTestCase {
         XCTAssertEqual(classes.map(\.name), ["CycleA_DCTest", "CycleB_DCTest"])
         XCTAssertEqual(classes.first!.inheritanceTypesNames, ["CycleB_DCTest"])
         XCTAssertEqual(classes.last!.inheritanceTypesNames, ["CycleA_DCTest"])
+
+        // Exercise DeclarationsCache.supertype(of:) via transitive inheritance lookup on the circular hierarchy.
+        _ = classes.first?.inherits(from: "CycleB_DCTest", includeTransitiveInheritance: true)
+        _ = classes.last?.inherits(from: "CycleA_DCTest", includeTransitiveInheritance: true)
     }
 }

--- a/Tests/SemanticsTests/DeclarationsCacheTests.swift
+++ b/Tests/SemanticsTests/DeclarationsCacheTests.swift
@@ -17,7 +17,7 @@
 //  limitations under the License.
 //
 
-@testable import HarmonizeSemantics
+import HarmonizeSemantics
 import XCTest
 
 /// Regression tests for the crash in `DeclarationsCache.supertype(of:)`.


### PR DESCRIPTION
### Fix crash in **DeclarationsCache.supertype(of:)**

`Crash: xctest at closure #1 in DeclarationsCache.supertype(of:)`

The method had two independent defects, either of which could crash the app.

**Problem 1 — data race**. supertype(of:) read typeInheritanceCache without holding the lock, while put(subtype:of:) could concurrently write to the same dictionary. Under Thread Sanitizer this caused undefined behaviour and a crash.

**Problem 2 — infinite recursion.** With a circular inheritance chain (A-->B-->A) the recursive call to supertype(of:) looped forever and crashed with a stack overflow.

### What changed. 

The recursive logic was extracted into a private helper findSupertype(of:in:visited:) that operates on a single snapshot of the cache taken under the lock. A visited: Set<String> parameter tracks already-seen types and breaks cycles. A variable shadowing the method name (supertype inside the closure) was also renamed to type.

### Tests.

One regression tests were added: verifies termination on a circular inheritance chain.