### PR TITLE
Bound project root walk at $HOME

### DIFF
--- a/Sources/Harmonize/Core/Finder/Resolver/ResolveProjectWorkingDirectory.swift
+++ b/Sources/Harmonize/Core/Finder/Resolver/ResolveProjectWorkingDirectory.swift
@@ -32,7 +32,8 @@ internal final class ResolveProjectWorkingDirectory {
         }
         
         var startingDirectory = URL(fileURLWithPath: currentFile)
-        
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser.standardized.path
+
         repeat {
             startingDirectory.appendPathComponent("..")
             startingDirectory.standardize()
@@ -41,11 +42,18 @@ internal final class ResolveProjectWorkingDirectory {
                 if !configFileIsReadable(at: startingDirectory) {
                     throw Config.FileError.noPermissionToViewFile
                 }
-                
+
                 return startingDirectory
             }
+
+            // Don't walk above the user's home directory: a stray `.harmonize.yaml`
+            // in an ancestor would otherwise hijack the project root and trigger a
+            // recursive scan of unrelated directories.
+            if startingDirectory.path == homeDirectory {
+                throw Config.FileError.configFileNotFound
+            }
         } while startingDirectory.path != "/"
-        
+
         throw Config.FileError.configFileNotFound
     }
     


### PR DESCRIPTION
`ResolveProjectWorkingDirectory` walked from the caller's `#file` up to `/`, which let a stray `.harmonize.yaml` in any ancestor directory hijack the project root and trigger a recursive scan of unrelated trees.

The walk now stops once it reaches the user's home directory. A `.harmonize.yaml` at `$HOME` itself is still picked up because the existence check runs before the boundary check, so projects rooted at `$HOME` keep working. The `/` terminator stays as a fallback for repos checked out outside `$HOME` (e.g. `/tmp`).